### PR TITLE
Enable splitting up image building and deployment

### DIFF
--- a/.github/workflows/build-and-deployment-workflow.yml
+++ b/.github/workflows/build-and-deployment-workflow.yml
@@ -49,10 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image-digest: ${{ steps.build-and-push-image.outputs.image-digest }}
-      stages-json: ${{ steps.prepare-stages-variables.outputs.stages-json }}
+      stages-json: ${{ steps.build-and-push-image.outputs.stages-json }}
     steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@v2
       - name: "Build image and push it to SetOps image registry"
         id: build-and-push-image
         uses: setopsco/github-actions/build-and-push-image@v1
@@ -67,14 +65,6 @@ jobs:
           build-cache-key-prefix: ${{ inputs.build-cache-key-prefix }}
           build-args: ${{ inputs.build-args }}
           build-secrets: ${{ secrets.build-secrets }}
-
-      # We need the stages variable in a json format for the next job, so
-      # we convert it with jq to JSON
-      - name: "Prepare setops-stages variable"
-        id: prepare-stages-variables
-        run: |
-          stages_json=$(echo ${{ inputs.setops-stages }} | jq -Rc 'split(" ")')
-          echo "::set-output name=stages-json::$stages_json"
 
   deploy:
     name: Setops Deployment

--- a/.github/workflows/build-and-deployment-workflow.yml
+++ b/.github/workflows/build-and-deployment-workflow.yml
@@ -51,6 +51,8 @@ jobs:
       image-digest: ${{ steps.build-and-push-image.outputs.image-digest }}
       stages-json: ${{ steps.build-and-push-image.outputs.stages-json }}
     steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
       - name: "Build image and push it to SetOps image registry"
         id: build-and-push-image
         uses: setopsco/github-actions/build-and-push-image@v1

--- a/build-and-push-image/action.yml
+++ b/build-and-push-image/action.yml
@@ -46,8 +46,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: "Checkout repository"
-      uses: actions/checkout@v2
     - name: "Detect SetOps target tag_names"
       id: build_tag_names
       run: |

--- a/build-and-push-image/action.yml
+++ b/build-and-push-image/action.yml
@@ -39,10 +39,15 @@ outputs:
   image-digest:
     value: ${{ steps.build_app.outputs.digest }}
     description: The digest of the image that can be referred to when creating releases
+  stages-json:
+    value: ${{ steps.prepare-stages-variables.outputs.stages-json }}
+    description: The given stages in stages format, so that they can be used as a matrix workflow input
 
 runs:
   using: "composite"
   steps:
+    - name: "Checkout repository"
+      uses: actions/checkout@v2
     - name: "Detect SetOps target tag_names"
       id: build_tag_names
       run: |
@@ -104,4 +109,12 @@ runs:
       run: |
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      shell: bash
+    # We need the stages variable in a json format for the next job, so
+    # we convert it with jq to JSON
+    - name: "Prepare setops-stages variable"
+      id: prepare-stages-variables
+      run: |
+        stages_json=$(echo ${{ inputs.setops-stages }} | jq -Rc 'split(" ")')
+        echo "::set-output name=stages-json::$stages_json"
       shell: bash


### PR DESCRIPTION
I want to enable building the image in parallel to running the test / qa task and then start the deployment when both tasks have finished. With these changes, I can setup my ci workflow like this:

```yaml
name: CI
on: push

jobs:
  test-and-qa:
    uses: ./.github/workflows/test-and-qa.yml

  setops-build-image:
    name: Setops build docker image
    runs-on: ubuntu-latest
    outputs:
      stages-json: ${{ steps.build-and-push-image.outputs.stages-json }}
      image-digest: ${{ steps.build-and-push-image.outputs.image-digest }}
    if: github.ref == 'refs/heads/production'
    steps:
      - name: "Detect setops stages based on the current branch"
        id: stages
        run: |
          if [ "$GITHUB_REF" == "refs/heads/production" ]; then
            echo '::set-output name=stages::production'
          fi
      - name: "Build image and push it to the SetOps image registry"
        id: build-and-push-image
        uses: setopsco/github-actions/build-and-push-image@enable-splitting-build-and-deployment
        with:
          setops-stages: ${{ steps.stages.outputs.stages }}
          other: env-vars-and-secrets

  setops-deployment:
    needs: [test-and-qa, setops-build-image]
    name: Setops Deployment
    strategy:
      fail-fast: false
      matrix:
        setops-stage: ${{ fromJson(needs.setops-build-image.outputs.stages-json) }}
    concurrency: setops-deployment-${{ github.ref }}
    runs-on: ubuntu-latest
    steps:
      - name: "Deploy apps on SetOps"
        id: deploy
        uses: setopsco/github-actions/deployment@v1
        with:
          image-digest: ${{ needs.setops-build-image.outputs.image-digest }}
          setops-stage: ${{ matrix.setops-stage }}
          other: env-vars-and-secrets
```

@kevinscholz This differs from the solution we discussed last week (our attempt was to hide the json conversion inside a deployment workflow) for two reasons:

* I think this would require to run the json conversion in a separate job opposed to simple step within a job
* We do not neccessarily need another pure deployment workflow; as I think that setting up a matrix as shown in my example is totally fine to do in a project and also gives more control.