### PR TITLE
:recycle: Increase retries to wait for successful deployments to 10 minutes

### DIFF
--- a/deployment/action.yml
+++ b/deployment/action.yml
@@ -26,7 +26,7 @@ inputs:
   number-of-retries-to-wait-for-successful-deployment:
     description: Max. number of times to wait for a succesful deployment (we sleep for 5 seconds between tries, so 12 equals 1 minute)
     required: false
-    default: "24"
+    default: "120"
   predeploy-command:
     description: A predeploy command to be run before activating the releases, e.g. for migrating the database
     required: false


### PR DESCRIPTION
Node scaling and application start up times can sometimes exceed the 2 minutes which are configured by default. This PR adjusts the default so that new projects are more likely to succeed without changing the value of this parameter.