### PR TITLE
:recycle: Support container deployments without health checks

### DIFF
--- a/.github/workflows/test-build-and-deployment-action.yml
+++ b/.github/workflows/test-build-and-deployment-action.yml
@@ -9,7 +9,7 @@ env:
   SETOPS_ORG: ${{ secrets.SETOPS_ORG }}
   SETOPS_PROJECT: "githubactions"
   SETOPS_STAGE: "testing"
-  SETOPS_APPS: "web" # todo: add "worker" in https://github.com/setopsco/github-actions/pull/10 and remove this comment
+  SETOPS_APPS: "web worker"
   SETOPS_USERNAME: "github-actions-setup@setops.co"
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ This workflow
 
 * Builds a docker image based on the `Dockerfile` in the project's root folder and pushes it to the SetOps registry.
 * Deploys the image to every app configured in `setops-apps`. If you configure more than one stage in `setops-stages`, the workflow will deploy each stage in parallel.
-
-CAUTION: The script assumes a configured [Container Health Check](https://docs.setops.co/latest/user/configuration/apps/#container-health-check) for *all* apps.
+* The script waits for the apps to run and checks, if the [Container Health Check](https://docs.setops.co/latest/user/configuration/apps/#container-health-check) succeeds for all apps if there is a health check configured.
 
 See the [workflow file](.github/workflows/build-and-deployment-workflow.yml) for all possible inputs.
 
@@ -145,7 +144,7 @@ The action
 * Creates releases for all configured apps
 * Runs the pre-deploy command within the first of the configured apps (`web` here)
 * Activates all releases
-* Waits until all releases are healthy
+* Waits until all releases are healthy (if a health check is configured)
 
 You can also use the action without the workflow:
 

--- a/deployment/action.yml
+++ b/deployment/action.yml
@@ -81,9 +81,17 @@ runs:
         for app in "${apps[@]}"; do
           release_id=${apps_with_release_id[$app]}
 
+          # Checking for health state of HEALTHY when health check is configured or otherwise accept UNKNOWN
+          app_info=$(sos app:ps $app)
+          expected_health_status=UNKNOWN
+          if echo "$app_info" | grep -A1  "Health Check:" | grep -q "   Command:"; then
+            expected_health_status=HEALTHY
+          fi
+
           for i in $(seq 1 $max_times); do
             sleep 5
-            if sos app:ps $app | grep -w -E "$release_id.*HEALTHY"; then break; fi
+
+            if sos app:ps $app | grep -w -E "$release_id.*RUNNING.*$expected_health_status"; then break; fi
             echo "Continue waiting for $app release $release_id"
 
             if [ $i = $max_times ]; then exit 1; fi


### PR DESCRIPTION
This PR adds the logic to check if a health check is configured and otherwise accept the "unknown" state. @hzeus since you initially introduced this script here, I'd be interested in your opinion of this solution.