### PR TITLE
:sparkles: Add pre-deploy command resources input

### DIFF
--- a/.github/workflows/build-and-deployment-workflow.yml
+++ b/.github/workflows/build-and-deployment-workflow.yml
@@ -5,7 +5,7 @@ on:
       setops-api-domain:
         description: The SetOps API URL to connect to
         required: false
-        default: 'api.setops.co'
+        default: "api.setops.co"
         type: string
       setops-organization:
         description: The SetOps organization
@@ -25,6 +25,15 @@ on:
       predeploy-command:
         required: false
         type: string
+      predeploy-command-detach-timeout:
+        required: false
+        type: string
+      predeploy-command-cpu:
+        required: false
+        type: string
+      predeploy-command-memory:
+        type: string
+        required: false
       build-context:
         description: The build context / directory where the Dockerfile is located, defaults to '.'
         required: false
@@ -99,3 +108,6 @@ jobs:
           setops-password: ${{ secrets.setops-password }}
           image-digest: ${{ needs.build.outputs.image-digest }}
           predeploy-command: ${{ inputs.predeploy-command }}
+          predeploy-command-detach-timeout: ${{ inputs.predeploy-command-detach-timeout }}
+          predeploy-command-cpu: ${{ inputs.predeploy-command-cpu }}
+          predeploy-command-memory: ${{ inputs.predeploy-command-memory }}

--- a/.github/workflows/test-build-and-deployment-action.yml
+++ b/.github/workflows/test-build-and-deployment-action.yml
@@ -1,4 +1,4 @@
-name: 'test-build-and-deployment-action'
+name: "test-build-and-deployment-action"
 
 on:
   push:
@@ -58,3 +58,7 @@ jobs:
           setops-password: ${{ secrets.SETOPS_PASSWORD }}
           image-digest: ${{ needs.build.outputs.image-digest }}
           setops-organization: ${{ env.SETOPS_ORG }}
+          predeploy-command: echo "Hello World"
+          predeploy-command-detach-timeout: 300s
+          predeploy-command-cpu: 128
+          predeploy-command-memory: 128

--- a/deployment/action.yml
+++ b/deployment/action.yml
@@ -25,7 +25,7 @@ inputs:
     required: true
   setops-api-domain:
     description: The SetOps API URL to connect to
-    default: 'api.setops.co'
+    default: "api.setops.co"
     required: false
   number-of-retries-to-wait-for-successful-deployment:
     description: Max. number of times to wait for a successful deployment (we sleep for 5 seconds between tries, so 12 equals 1 minute)
@@ -38,6 +38,12 @@ inputs:
     description: Detach timeout for one-off task that runs predeploy command (h = hours, m = minutes, s = second, ms = milliseconds)
     required: false
     default: "10m"
+  predeploy-command-cpu:
+    description: CPU units to provide to the predeploy command. 1024 units are 1 vCPU. Defaults to the configured app CPU units if not passed in.
+    required: false
+  predeploy-command-memory:
+    description: Memory to provide to the predeploy command in MB. Defaults to the configured app memory if not passed in.
+    required: false
 runs:
   using: "composite"
   steps:
@@ -69,7 +75,10 @@ runs:
           echo "Run predeploy command"
           first_app=${apps[0]}
           release_id_of_first_app=${apps_with_release_id[$first_app]}
-          task_id=$(sos --app "$first_app" task:run --detach-timeout ${{ inputs.predeploy-command-detach-timeout }} --release "$release_id_of_first_app" --entrypoint sh -- -c "$PREDEPLOY_COMMAND && echo SETOPS_SUCCESS" | tee /dev/stderr | grep -oP '^ID:   \K[a-z0-9]+$')
+          resource_parameters=''
+          [ ${#PREDEPLOY_COMMAND_CPU} -gt 0 ] && resource_parameters="$resource_parameters --cpu $PREDEPLOY_COMMAND_CPU"
+          [ ${#PREDEPLOY_COMMAND_MEMORY} -gt 0 ] && resource_parameters="$resource_parameters --memory $PREDEPLOY_COMMAND_MEMORY"
+          task_id=$(sos --app "$first_app" task:run --detach-timeout ${{ inputs.predeploy-command-detach-timeout }} --release "$release_id_of_first_app" --entrypoint sh $resource_parameters -- -c "$PREDEPLOY_COMMAND && echo SETOPS_SUCCESS" | tee /dev/stderr | grep -oP '^ID:   \K[a-z0-9]+$')
 
           # Checking the expected SETOPS_SUCCESS log after task finished to ensure that all logs are collected
           sos --app "$first_app" log -n 50 --task "$task_id" | grep SETOPS_SUCCESS > /dev/null
@@ -109,4 +118,7 @@ runs:
       env:
         # Providing it as an env variable to prevent quoting issues
         PREDEPLOY_COMMAND: ${{ inputs.predeploy-command }}
+
+        PREDEPLOY_COMMAND_CPU: ${{ inputs.predeploy-command-cpu }}
+        PREDEPLOY_COMMAND_MEMORY: ${{ inputs.predeploy-command-memory }}
       shell: bash


### PR DESCRIPTION
Adds the ability to request specific resources for pre-deploy commands via the the following input variables:

```
predeploy-command-cpu
predeploy-command-memory
```