### PR TITLE
:arrow_up: Update versions of docker and cache actions

### DIFF
--- a/build-and-push-image/action.yml
+++ b/build-and-push-image/action.yml
@@ -74,9 +74,9 @@ runs:
         echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
       shell: bash
     - name: "Set up Docker Buildx"
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ steps.get_date.outputs.date }}-${{ inputs.build-cache-key-prefix }}-${{ github.sha }}
@@ -91,7 +91,7 @@ runs:
         setops_password: ${{ inputs.setops-password }}
     - name: Build and push app
       id: build_app
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         context: ${{ inputs.build-context }}
         push: true


### PR DESCRIPTION
I hope that this will avoid deprecation warnings as described in 

* https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
* https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

